### PR TITLE
Fix Android support configuration to avoid ClassNotFoundException

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,8 @@
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="applicationPreferences">
-                <param name="android-package" value="com.appgiraffe.plugins.applicationPreferences"/>
+               <!-- android-package value should contain fully qualified class name -->
+                <param name="android-package" value="com.appgiraffe.plugins.applicationPreferences.applicationPreferences"/>
             </feature>
         </config-file>
         <source-file src="src/android/applicationPreferences.java" target-dir="src/com/appgiraffe/plugins/applicationPreferences" />      

--- a/src/android/applicationPreferences.java
+++ b/src/android/applicationPreferences.java
@@ -44,7 +44,8 @@ public class applicationPreferences extends CordovaPlugin {
             } else if (action.equals("set")) {
                 String key = args.getString(0);
                 String value = args.getString(1);
-                if (sharedPrefs.contains(key)) {
+                //we should avoid this condition because it doesnt allow adding new <key,value>  
+                //if (sharedPrefs.contains(key)) {
                     Editor editor = sharedPrefs.edit();
                     if ("true".equals(value.toLowerCase()) || "false".equals(value.toLowerCase())) {
                         editor.putBoolean(key, Boolean.parseBoolean(value));
@@ -54,10 +55,12 @@ public class applicationPreferences extends CordovaPlugin {
                     editor.commit();
                     callbackContext.success();
                     return true;
-                } else {
+            /*    
+            } else {
                 	callbackContext.error("No such property called " + key);
                 	return false;
                 }
+            */    
             } else if (action.equals("load")) {
                 JSONObject obj = new JSONObject();
                 Map<String,?> prefs = sharedPrefs.getAll();


### PR DESCRIPTION
- When i use the plugin, i have a ClassNotFoundException beacause the configuration file does not include the fully qualified name of the plugin class.
- Another fix is to remove the condition because it allows only changing an exisiting value and not adding a new one.